### PR TITLE
Fix: Add missing provider_type field to ToolNodeData

### DIFF
--- a/src/dsl_model/nodes.py
+++ b/src/dsl_model/nodes.py
@@ -138,6 +138,7 @@ class ToolNodeData(BaseNodeData):
     # Removed type field to match dify/api
     provider_id: str = Field(min_length=1)
     provider_name: str = Field(min_length=1)
+    provider_type: Optional[str] = Field(default=None)
     tool_name: str = Field(min_length=1)
     tool_label: str = Field(default="")
     tool_parameters: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
- Added provider_type: Optional[str] field to ToolNodeData class
- This field was missing causing tool nodes to lose provider_type information during save/load
- Fixes issue where DuckDuckGo and other tool nodes couldn't render properly in Dify after workflow modifications